### PR TITLE
fix(og): correct brand/meta on per-link cards + script refactor

### DIFF
--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -148,25 +148,56 @@ function ogSvg(shortLink, destShort, path, userDomain, qrDataUri) {
 </svg>`;
 }
 
-function stubHtml({ path, ogImage, title, description, destination }) {
+// Mirrors the meta-tag shape of webapp/index.html (site root) so per-link
+// pages are unified with the homepage: og:type/site_name/locale, full
+// og:image set, full twitter:* set, canonical, etc.
+function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
+  const destShort = stripProto(destination);
+  const title = `${shortLink} · ${truncate(destShort, 48)}`;
+  const description = `Short link ${shortLink} redirects to ${destShort} — managed via glnk.dev.`;
+  const imageAlt = `${shortLink} → ${destShort}`;
   return `<!doctype html>
-<html lang="en"><head>
-<meta charset="utf-8">
-<title>${escapeXml(title)}</title>
-<meta name="description" content="${escapeXml(description)}">
-<meta property="og:title" content="${escapeXml(title)}">
-<meta property="og:description" content="${escapeXml(description)}">
-<meta property="og:url" content="${PUBLIC_URL}${path}">
-<meta property="og:image" content="${ogImage}">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
-<meta name="twitter:card" content="summary_large_image">
-<meta http-equiv="refresh" content="0;url=${escapeXml(destination)}">
-<link rel="canonical" href="${escapeXml(destination)}">
-</head><body>
-<script>window.location.replace(${JSON.stringify(destination)});</script>
-<p>Redirecting to <a href="${escapeXml(destination)}">${escapeXml(destination)}</a>...</p>
-</body></html>`;
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <title>${escapeXml(title)}</title>
+  <meta name="title" content="${escapeXml(title)}" />
+  <meta name="description" content="${escapeXml(description)}" />
+  <meta name="author" content="glnk.dev" />
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+
+  <link rel="canonical" href="${escapeXml(destination)}" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="${escapeXml(pageUrl)}" />
+  <meta property="og:title" content="${escapeXml(title)}" />
+  <meta property="og:description" content="${escapeXml(description)}" />
+  <meta property="og:image" content="${escapeXml(ogImage)}" />
+  <meta property="og:image:alt" content="${escapeXml(imageAlt)}" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:site_name" content="glnk.dev" />
+  <meta property="og:locale" content="en_US" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="${escapeXml(pageUrl)}" />
+  <meta name="twitter:title" content="${escapeXml(title)}" />
+  <meta name="twitter:description" content="${escapeXml(description)}" />
+  <meta name="twitter:image" content="${escapeXml(ogImage)}" />
+  <meta name="twitter:image:alt" content="${escapeXml(imageAlt)}" />
+  <meta name="twitter:creator" content="@GlnkDev" />
+  <meta name="twitter:site" content="@GlnkDev" />
+
+  <meta http-equiv="refresh" content="0;url=${escapeXml(destination)}" />
+</head>
+<body>
+  <script>window.location.replace(${JSON.stringify(destination)});</script>
+  <p>Redirecting to <a href="${escapeXml(destination)}">${escapeXml(destination)}</a>...</p>
+</body>
+</html>`;
 }
 
 function writeOut(file, data) {
@@ -186,8 +217,6 @@ for await (const [path, dest] of Object.entries(routes)) {
   const s = slug(path);
   const shortLink = `${stripProto(PUBLIC_URL)}${path}`;
   const destShort = stripProto(String(dest));
-  const title = truncate(destShort, 40);
-  const description = `via ${shortLink}`;
 
   const qrDataUri = await makeQrDataUri(String(dest));
   const png = new Resvg(ogSvg(shortLink, destShort, path, stripProto(PUBLIC_URL), qrDataUri), {
@@ -206,10 +235,16 @@ for await (const [path, dest] of Object.entries(routes)) {
   writeOut(join(OUT_DIR, 'og', `${s}.png`), png);
   writeOut(
     join(OUT_DIR, path, 'index.html'),
-    stubHtml({ path, ogImage: `${PUBLIC_URL}/og/${s}.png`, title, description, destination: String(dest) }),
+    stubHtml({
+      path,
+      ogImage: `${PUBLIC_URL}/og/${s}.png`,
+      shortLink,
+      destination: String(dest),
+      pageUrl: `${PUBLIC_URL}${path}`,
+    }),
   );
 
-  console.log(`[og] ${path}  →  ${title}`);
+  console.log(`[og] ${path}  →  ${destShort}`);
   generated++;
 }
 

--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
-// Per-link OG image + HTML stub generator.
-// Runs after `vite build`. Reads build/glnk.yaml, emits:
-//   build/og/{slug}.png        — per-link OG image (1200x630), brand-matched
-//   build/{path}/index.html    — stub bot-scrapers receive, with per-link meta
+// Per-link OG image + HTML stub generator. Runs after `vite build`.
+// Reads <OUT>/glnk.yaml and, for each non-wildcard route, emits:
+//   <OUT>/og/{slug}.png      — 1200x630 share card (brand + /path + QR + redirect target)
+//   <OUT>/{path}/index.html  — bot-facing stub mirroring webapp/index.html's meta shape
 //
-// Inputs (env, matches webapp/action.yaml conventions):
-//   GLNK_USERNAME      required for user sites; empty for homepage (script exits 0)
-//   GLNK_OUTPUT_DIR    default: build
-//   GLNK_INPUT_YAML    default: <GLNK_OUTPUT_DIR>/glnk.yaml
-//   GLNK_PUBLIC_URL    default: https://<GLNK_USERNAME>.glnk.dev
-//   GLNK_FAVICON       default: public/favicon.png (path to brand mark PNG)
+// Env (matches webapp/action.yaml conventions):
+//   GLNK_USERNAME    required for user sites; empty for homepage (script exits 0)
+//   GLNK_OUTPUT_DIR  default: build
+//   GLNK_INPUT_YAML  default: <GLNK_OUTPUT_DIR>/glnk.yaml
+//   GLNK_PUBLIC_URL  honoured only when a full http(s) URL; else falls back to
+//                    https://<USERNAME>.glnk.dev (CI passes empty / a Vite --base)
+//   GLNK_FAVICON     default: public/favicon.png
+//   GLNK_OG_BG       default: public/assets/og-bg.png
 
 import { Resvg } from '@resvg/resvg-js';
 import { parse as parseYaml } from 'yaml';
@@ -17,18 +19,24 @@ import QRCode from 'qrcode';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+// ---------- config ----------------------------------------------------------
+
+const BRAND = { name: 'glnk.dev', twitter: '@GlnkDev', locale: 'en_US' };
+const CARD = { width: 1200, height: 630 };
+const FONT_FAMILY = 'Inter, -apple-system, Helvetica, Arial, sans-serif';
+
 const USERNAME = process.env.GLNK_USERNAME ?? '';
 const OUT_DIR = process.env.GLNK_OUTPUT_DIR ?? 'build';
 const YAML_PATH = process.env.GLNK_INPUT_YAML ?? join(OUT_DIR, 'glnk.yaml');
+const FAVICON_PATH = process.env.GLNK_FAVICON ?? 'public/favicon.png';
+const OG_BG_PATH = process.env.GLNK_OG_BG ?? 'public/assets/og-bg.png';
+
 // GLNK_PUBLIC_URL is honoured only when it's a full http(s) URL — in CI it's
 // often empty (env var still set), or a Vite --base path like "/webapp/".
 const rawPublicUrl = process.env.GLNK_PUBLIC_URL ?? '';
 const PUBLIC_URL = /^https?:\/\//.test(rawPublicUrl)
   ? rawPublicUrl
-  : USERNAME ? `https://${USERNAME}.glnk.dev` : '';
-const FAVICON_PATH = process.env.GLNK_FAVICON ?? 'public/favicon.png';
-const BRAND_CARD_PATH = process.env.GLNK_BRAND_CARD ?? 'public/assets/og.png';
-const OG_BG_PATH = process.env.GLNK_OG_BG ?? 'public/assets/og-bg.png';
+  : USERNAME ? `https://${USERNAME}.${BRAND.name}` : '';
 
 if (!USERNAME) {
   console.log('[og] GLNK_USERNAME not set — skipping (homepage mode)');
@@ -39,28 +47,13 @@ if (!existsSync(YAML_PATH)) {
   process.exit(1);
 }
 
+// ---------- helpers ---------------------------------------------------------
+
 const stripProto = (u) => u.replace(/^https?:\/\//, '').replace(/\/$/, '');
 const truncate = (s, n = 50) => (s.length <= n ? s : s.slice(0, n - 1) + '…');
 const slug = (p) => p.replace(/^\/+/, '').replace(/\//g, '-').replace(/[^a-z0-9-]/gi, '-').toLowerCase() || 'home';
 const escapeXml = (s) =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-
-const faviconDataUri = existsSync(FAVICON_PATH)
-  ? `data:image/png;base64,${readFileSync(FAVICON_PATH).toString('base64')}`
-  : null;
-const brandCardDataUri = existsSync(BRAND_CARD_PATH)
-  ? `data:image/jpeg;base64,${readFileSync(BRAND_CARD_PATH).toString('base64')}`
-  : null;
-const ogBgDataUri = existsSync(OG_BG_PATH)
-  ? `data:image/png;base64,${readFileSync(OG_BG_PATH).toString('base64')}`
-  : null;
-
-function wrapTitle(text, maxLen = 30) {
-  if (text.length <= maxLen) return [text];
-  const idx = text.lastIndexOf('/', maxLen);
-  const split = idx > 0 ? idx : maxLen;
-  return [text.slice(0, split), text.slice(split)];
-}
 
 function wrapDest(text, maxLen = 38, maxLines = 3) {
   const lines = [];
@@ -71,15 +64,19 @@ function wrapDest(text, maxLen = 38, maxLines = 3) {
     lines.push(rest.slice(0, split));
     rest = rest.slice(split);
   }
-  if (rest.length > maxLen) {
-    rest = rest.slice(0, maxLen - 1) + '…';
-  }
-  lines.push(rest);
+  lines.push(rest.length > maxLen ? rest.slice(0, maxLen - 1) + '…' : rest);
   return lines;
 }
 
+function pngDataUri(path) {
+  return existsSync(path) ? `data:image/png;base64,${readFileSync(path).toString('base64')}` : null;
+}
+
+const faviconDataUri = pngDataUri(FAVICON_PATH);
+const ogBgDataUri = pngDataUri(OG_BG_PATH);
+
 async function makeQrDataUri(url) {
-  return await QRCode.toDataURL(url, {
+  return QRCode.toDataURL(url, {
     errorCorrectionLevel: 'M',
     margin: 1,
     color: { dark: '#0f172a', light: '#ffffff' },
@@ -87,74 +84,71 @@ async function makeQrDataUri(url) {
   });
 }
 
-function ogSvg(shortLink, destShort, path, userDomain, qrDataUri) {
-  const destLines = wrapDest(destShort, 38, 3);
-  const titleLines = wrapTitle(shortLink, 30);
-  const brandMark = faviconDataUri
-    ? `<image href="${faviconDataUri}" x="80" y="185" width="40" height="36"/>
-       <text x="134" y="214" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="26" font-weight="700" fill="#0f172a">${escapeXml(userDomain)}</text>`
-    : `<text x="80" y="214" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="26" font-weight="700" fill="#f97316">${escapeXml(userDomain)}</text>`;
+function writeOut(file, data) {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, data);
+}
 
-  // Smaller white QR card positioned more centrally on the right to keep wave corners visible
-  const cardX = 770, cardY = 145, cardSize = 340;
+// ---------- SVG composition --------------------------------------------------
+
+function brandRow(userDomain) {
+  const icon = faviconDataUri
+    ? `<image href="${faviconDataUri}" x="80" y="185" width="40" height="36"/>`
+    : '';
+  const textX = faviconDataUri ? 134 : 80;
+  const fill = faviconDataUri ? '#0f172a' : '#f97316';
+  return `${icon}<text x="${textX}" y="214" font-family="${FONT_FAMILY}" font-size="26" font-weight="700" fill="${fill}">${escapeXml(userDomain)}</text>`;
+}
+
+function qrCardBlock(qrDataUri) {
+  const x = 770, y = 145, size = 340;
   const qrSize = 240;
-  const qrX = cardX + (cardSize - qrSize) / 2;
-  const qrY = cardY + 64;
+  const qrX = x + (size - qrSize) / 2;
+  const qrY = y + 64;
   const brandInCard = faviconDataUri
-    ? `<image href="${faviconDataUri}" x="${cardX + cardSize / 2 - 64}" y="${cardY + 22}" width="28" height="25"/>
-       <text x="${cardX + cardSize / 2 - 30}" y="${cardY + 42}" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="20" font-weight="700" fill="#0f172a">glnk.dev</text>`
-    : `<text x="${cardX + cardSize / 2}" y="${cardY + 42}" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="20" font-weight="700" fill="#0f172a" text-anchor="middle">glnk.dev</text>`;
-  const qrCard = `
-    <rect x="${cardX}" y="${cardY}" width="${cardSize}" height="${cardSize}" rx="28" ry="28" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
+    ? `<image href="${faviconDataUri}" x="${x + size / 2 - 64}" y="${y + 22}" width="28" height="25"/>
+       <text x="${x + size / 2 - 30}" y="${y + 42}" font-family="${FONT_FAMILY}" font-size="20" font-weight="700" fill="#0f172a">${BRAND.name}</text>`
+    : `<text x="${x + size / 2}" y="${y + 42}" font-family="${FONT_FAMILY}" font-size="20" font-weight="700" fill="#0f172a" text-anchor="middle">${BRAND.name}</text>`;
+  return `
+    <rect x="${x}" y="${y}" width="${size}" height="${size}" rx="28" ry="28" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
     ${brandInCard}
     <image href="${qrDataUri}" x="${qrX}" y="${qrY}" width="${qrSize}" height="${qrSize}"/>
-    <text x="${cardX + cardSize / 2}" y="${cardY + cardSize - 22}" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#94a3b8" text-anchor="middle">Scan to open</text>
+    <text x="${x + size / 2}" y="${y + size - 22}" font-family="${FONT_FAMILY}" font-size="15" font-weight="500" fill="#94a3b8" text-anchor="middle">Scan to open</text>
   `;
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <defs>
-    <radialGradient id="aura" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.55"/>
-      <stop offset="60%" stop-color="#3b82f6" stop-opacity="0.18"/>
-      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="warmSoft" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fed7aa" stop-opacity="0.7"/>
-      <stop offset="100%" stop-color="#fdba74" stop-opacity="0.85"/>
-    </linearGradient>
-  </defs>
+}
 
-  <rect width="1200" height="630" fill="#fffaf5"/>
+function ogSvg({ path, destShort, userDomain, qrDataUri }) {
+  const destLines = wrapDest(destShort, 38, 3);
+  const bg = ogBgDataUri
+    ? `<image href="${ogBgDataUri}" x="0" y="0" width="${CARD.width}" height="${CARD.height}" preserveAspectRatio="xMidYMid slice"/>`
+    : '';
+  const destBlock = destLines
+    .map((line, i) => `<text x="80" y="${390 + i * 30}" font-family="${FONT_FAMILY}" font-size="22" font-weight="600" fill="#0f172a">${escapeXml(line)}</text>`)
+    .join('\n  ');
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${CARD.width}" height="${CARD.height}" viewBox="0 0 ${CARD.width} ${CARD.height}">
+  <rect width="${CARD.width}" height="${CARD.height}" fill="#fffaf5"/>
+  ${bg}
+  <rect x="0" y="0" width="8" height="${CARD.height}" fill="#2563eb"/>
 
-  <!-- Background: pre-cleaned og-bg.png (waves at corners, center cleared) -->
-  ${ogBgDataUri ? `<image href="${ogBgDataUri}" x="0" y="0" width="1200" height="630" preserveAspectRatio="xMidYMid slice"/>` : ''}
+  ${brandRow(userDomain)}
 
-  <!-- Left blue accent line -->
-  <rect x="0" y="0" width="8" height="630" fill="#2563eb"/>
+  <text x="80" y="290" font-family="${FONT_FAMILY}" font-size="56" font-weight="700" fill="#f97316">${escapeXml(path)}</text>
 
-  <!-- Brand mark top-left -->
-  ${brandMark}
+  <text x="80" y="355" font-family="${FONT_FAMILY}" font-size="20" fill="#94a3b8">Redirects to</text>
+  ${destBlock}
 
-  <!-- Big title: just the /path (hostname lives in the brand row above) -->
-  <text x="80" y="290" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="56" font-weight="700" fill="#f97316">${escapeXml(path)}</text>
-
-  <!-- Tagline label -->
-  <text x="80" y="355" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="20" fill="#94a3b8">Redirects to</text>
-  <!-- Destination (wraps to up to 3 lines) -->
-  ${destLines.map((line, i) => `<text x="80" y="${390 + i * 30}" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="22" font-weight="600" fill="#0f172a">${escapeXml(line)}</text>`).join('\n  ')}
-
-
-  <!-- Right-side QR card -->
-  ${qrCard}
+  ${qrCardBlock(qrDataUri)}
 </svg>`;
 }
 
-// Mirrors the meta-tag shape of webapp/index.html (site root) so per-link
-// pages are unified with the homepage: og:type/site_name/locale, full
-// og:image set, full twitter:* set, canonical, etc.
-function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
+// ---------- HTML stub --------------------------------------------------------
+
+// Mirrors the meta shape of webapp/index.html so per-link stubs unfurl
+// consistently with the site root.
+function stubHtml({ pageUrl, ogImage, shortLink, destination }) {
   const destShort = stripProto(destination);
   const title = `${shortLink} · ${truncate(destShort, 48)}`;
-  const description = `Short link ${shortLink} redirects to ${destShort} — managed via glnk.dev.`;
+  const description = `Short link ${shortLink} redirects to ${destShort} — managed via ${BRAND.name}.`;
   const imageAlt = `${shortLink} → ${destShort}`;
   return `<!doctype html>
 <html lang="en">
@@ -165,7 +159,7 @@ function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
   <title>${escapeXml(title)}</title>
   <meta name="title" content="${escapeXml(title)}" />
   <meta name="description" content="${escapeXml(description)}" />
-  <meta name="author" content="glnk.dev" />
+  <meta name="author" content="${BRAND.name}" />
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
 
   <link rel="canonical" href="${escapeXml(destination)}" />
@@ -176,11 +170,11 @@ function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
   <meta property="og:description" content="${escapeXml(description)}" />
   <meta property="og:image" content="${escapeXml(ogImage)}" />
   <meta property="og:image:alt" content="${escapeXml(imageAlt)}" />
-  <meta property="og:image:width" content="1200" />
-  <meta property="og:image:height" content="630" />
+  <meta property="og:image:width" content="${CARD.width}" />
+  <meta property="og:image:height" content="${CARD.height}" />
   <meta property="og:image:type" content="image/png" />
-  <meta property="og:site_name" content="glnk.dev" />
-  <meta property="og:locale" content="en_US" />
+  <meta property="og:site_name" content="${BRAND.name}" />
+  <meta property="og:locale" content="${BRAND.locale}" />
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="${escapeXml(pageUrl)}" />
@@ -188,8 +182,8 @@ function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
   <meta name="twitter:description" content="${escapeXml(description)}" />
   <meta name="twitter:image" content="${escapeXml(ogImage)}" />
   <meta name="twitter:image:alt" content="${escapeXml(imageAlt)}" />
-  <meta name="twitter:creator" content="@GlnkDev" />
-  <meta name="twitter:site" content="@GlnkDev" />
+  <meta name="twitter:creator" content="${BRAND.twitter}" />
+  <meta name="twitter:site" content="${BRAND.twitter}" />
 
   <meta http-equiv="refresh" content="0;url=${escapeXml(destination)}" />
 </head>
@@ -200,51 +194,59 @@ function stubHtml({ path, ogImage, shortLink, destination, pageUrl }) {
 </html>`;
 }
 
-function writeOut(file, data) {
-  mkdirSync(dirname(file), { recursive: true });
-  writeFileSync(file, data);
+// ---------- rendering --------------------------------------------------------
+
+const RESVG_OPTS = {
+  fitTo: { mode: 'width', value: CARD.width },
+  font: {
+    fontFiles: [
+      'node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2',
+      'node_modules/@fontsource/inter/files/inter-latin-700-normal.woff2',
+    ],
+    loadSystemFonts: true,
+    defaultFontFamily: 'Inter',
+    serifFamily: 'Inter',
+    sansSerifFamily: 'Inter',
+  },
+};
+
+async function renderRoute(path, dest) {
+  const destination = String(dest);
+  const userDomain = stripProto(PUBLIC_URL);
+  const shortLink = `${userDomain}${path}`;
+  const destShort = stripProto(destination);
+  const s = slug(path);
+
+  const qrDataUri = await makeQrDataUri(destination);
+  const png = new Resvg(
+    ogSvg({ path, destShort, userDomain, qrDataUri }),
+    RESVG_OPTS,
+  ).render().asPng();
+  writeOut(join(OUT_DIR, 'og', `${s}.png`), png);
+  writeOut(
+    join(OUT_DIR, path, 'index.html'),
+    stubHtml({
+      pageUrl: `${PUBLIC_URL}${path}`,
+      ogImage: `${PUBLIC_URL}/og/${s}.png`,
+      shortLink,
+      destination,
+    }),
+  );
+  console.log(`[og] ${path}  →  ${destShort}`);
 }
+
+// ---------- main ------------------------------------------------------------
 
 const routes = parseYaml(readFileSync(YAML_PATH, 'utf8')) ?? {};
 let generated = 0, skipped = 0;
 
-for await (const [path, dest] of Object.entries(routes)) {
+for (const [path, dest] of Object.entries(routes)) {
   if (path.includes('{$') || String(dest).includes('{$')) {
     console.log(`[og] ${path}  (wildcard — falls back to default OG)`);
     skipped++;
     continue;
   }
-  const s = slug(path);
-  const shortLink = `${stripProto(PUBLIC_URL)}${path}`;
-  const destShort = stripProto(String(dest));
-
-  const qrDataUri = await makeQrDataUri(String(dest));
-  const png = new Resvg(ogSvg(shortLink, destShort, path, stripProto(PUBLIC_URL), qrDataUri), {
-    fitTo: { mode: 'width', value: 1200 },
-    font: {
-      fontFiles: [
-        'node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2',
-        'node_modules/@fontsource/inter/files/inter-latin-700-normal.woff2',
-      ],
-      loadSystemFonts: true,
-      defaultFontFamily: 'Inter',
-      serifFamily: 'Inter',
-      sansSerifFamily: 'Inter',
-    },
-  }).render().asPng();
-  writeOut(join(OUT_DIR, 'og', `${s}.png`), png);
-  writeOut(
-    join(OUT_DIR, path, 'index.html'),
-    stubHtml({
-      path,
-      ogImage: `${PUBLIC_URL}/og/${s}.png`,
-      shortLink,
-      destination: String(dest),
-      pageUrl: `${PUBLIC_URL}${path}`,
-    }),
-  );
-
-  console.log(`[og] ${path}  →  ${destShort}`);
+  await renderRoute(path, dest);
   generated++;
 }
 

--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -20,7 +20,12 @@ import { dirname, join } from 'node:path';
 const USERNAME = process.env.GLNK_USERNAME ?? '';
 const OUT_DIR = process.env.GLNK_OUTPUT_DIR ?? 'build';
 const YAML_PATH = process.env.GLNK_INPUT_YAML ?? join(OUT_DIR, 'glnk.yaml');
-const PUBLIC_URL = process.env.GLNK_PUBLIC_URL ?? (USERNAME ? `https://${USERNAME}.glnk.dev` : '');
+// GLNK_PUBLIC_URL is honoured only when it's a full http(s) URL — in CI it's
+// often empty (env var still set), or a Vite --base path like "/webapp/".
+const rawPublicUrl = process.env.GLNK_PUBLIC_URL ?? '';
+const PUBLIC_URL = /^https?:\/\//.test(rawPublicUrl)
+  ? rawPublicUrl
+  : USERNAME ? `https://${USERNAME}.glnk.dev` : '';
 const FAVICON_PATH = process.env.GLNK_FAVICON ?? 'public/favicon.png';
 const BRAND_CARD_PATH = process.env.GLNK_BRAND_CARD ?? 'public/assets/og.png';
 const OG_BG_PATH = process.env.GLNK_OG_BG ?? 'public/assets/og-bg.png';


### PR DESCRIPTION
## Summary

Three commits, follow-up to #54 and #55, off of seeing real unfurls:

### `fd98bb5` fix(og): fall back to default URL when GLNK_PUBLIC_URL isn't a full URL

In CI the env var is always set — empty string when the input is blank, or a Vite `--base` path like `/webapp/` on deploy previews. The previous code accepted both as-is, leading to:

- `aslan.glnk.dev/cv`: brand row blank, `og:url` / `og:image` emitted as bare paths.
- `glnk-dev.github.io/webapp/deploy/edit`: brand row read \"/webapp\".

We now honour `GLNK_PUBLIC_URL` only when it starts with `http(s)://`; otherwise fall back to `https://<USERNAME>.glnk.dev`.

### `59c4798` feat(og): unify per-link stub meta with site root

The inspector on a deployed per-link page flagged `og:site_name` missing and the description as 7 characters (the placeholder). The stub now mirrors `webapp/index.html`'s meta shape:

- `og:type`, `og:site_name`, `og:locale`, `og:image:alt` / `:width` / `:height` / `:type`
- Full `twitter:*` set (`url`, `title`, `description`, `image`, `image:alt`, `creator`, `site`)
- `name=\"title\"` / `\"author\"` / `\"robots\"`, `canonical`

Title and description are built per-link (`shortLink · destination`, full-sentence description) so they land in the SEO snippet length sweet spot.

### `73e56ea` refactor(og): tighten generate-og.mjs

No behaviour change. Reorganises into config / SVG composition / HTML stub sections and drops accumulated POC cruft:

- `BRAND` / `CARD` / `FONT_FAMILY` constants reused across SVG, stub, and Resvg config.
- `pngDataUri()` helper for the `existsSync + base64` pattern.
- `brandRow()` and `qrCardBlock()` extracted out of `ogSvg()`.
- `ogSvg()` now takes an options object instead of five positional args.
- `renderRoute()` extracted from the main loop.
- Dropped unused `wrapTitle()` and `BRAND_CARD_PATH` plumbing.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — only pre-existing AuthContext warning
- [x] `GLNK_USERNAME=lucetre node scripts/generate-og.mjs` regenerates valid 1200x630 PNGs + 41-line stubs with full meta block
- [x] empty `GLNK_PUBLIC_URL` env — brand text resolves to `lucetre.glnk.dev`, not blank
- [x] `GLNK_PUBLIC_URL=/webapp/` — fallback kicks in, no `/webapp` in brand
- [ ] post-deploy: re-scan `aslan.glnk.dev/cv` with the inspector — `og:site_name` present, description in the 80-160 char range

🤖 Generated with [Claude Code](https://claude.com/claude-code)