### PR TITLE
chore(action): switch to client-id per create-github-app-token@v3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
       uses: google-github-actions/get-secretmanager-secrets@v3
       with:
         secrets: |-
-          gh_app_id:glnk-dev/gh-app-glnk-manager-id
+          gh_app_client_id:glnk-dev/gh-app-glnk-manager-client-id
           gh_app_private_key:glnk-dev/gh-app-glnk-manager-private-key
           firebase_api_key:glnk-dev/glnk-dev-firebase-api-key
           firebase_app_id:glnk-dev/glnk-dev-firebase-app-id
@@ -50,7 +50,7 @@ runs:
       if: inputs.GLNK_ACCESS_MODE != 'homepage'
       id: app-token
       with:
-        app-id: ${{ steps.secrets.outputs.gh_app_id }}
+        client-id: ${{ steps.secrets.outputs.gh_app_client_id }}
         private-key: ${{ steps.secrets.outputs.gh_app_private_key }}
         owner: ${{ github.repository_owner }}
         repositories: community


### PR DESCRIPTION
## Summary

The v3 action deprecates `app-id` in favour of `client-id` (warning observed on every deploy run). Switch to the new `gh-app-glnk-manager-client-id` GCP secret; the output name in `get-secretmanager-secrets` is renamed to `gh_app_client_id` to match.

Pairs with [glnk-dev/terraform-provider#chore-gh-app-client-id](https://github.com/glnk-dev/terraform-provider) (IAM swap) and the community PR (workflow inputs).

## Test plan

- [x] Local YAML syntax check
- [ ] Smoke deploy on a single user repo (e.g. lucetre) after merge — confirm no `app-id` deprecation warning and token issued